### PR TITLE
完善测试脚本

### DIFF
--- a/cephadm/3-deploy-cephfs.md
+++ b/cephadm/3-deploy-cephfs.md
@@ -451,6 +451,55 @@ ceph tell mds.bjcfs01.mn01.zxhhrq client ls
 
 访问 [elbencho](https://github.com/breuner/elbencho/releases) 下载工具
 
+经过测试，新版本的elbencho貌似有内存泄漏问题。建议使用v3.0.19版本。
+
+#### 单文件测试
+
+```bash
+#!/usr/bin/env bash
+
+set -x 
+
+TESTDIR=/share/test
+ELBENCHO=/usr/local/bin/elbencho
+RESFILE=fs.log
+THREADS_LIST="1 4 16 64"
+HOSTS_LIST="gn001 gn[001-004] gn[001-016]"
+USER=root
+
+FIRST_HOST=$(echo $HOSTS_LIST | awk '{print $1}')
+LAST_HOST=$(echo $HOSTS_LIST | awk '{print $NF}')
+LAST_THREAD=$(echo $THREADS_LIST | awk '{print $NF}')
+
+pdsh -w $USER@$LAST_HOST $ELBENCHO --service
+
+for host in $HOSTS_LIST; do
+    if [ "$host" == "$FIRST_HOST" ]; then
+        thread_list=$THREADS_LIST
+    else
+        thread_list=$LAST_THREAD
+    fi
+
+    for threads in $thread_list; do
+
+          SIZE=$(($TOTAL/$threads))g
+
+          # Sequentially write and read $THREADS large files
+          $ELBENCHO --hosts $host -w -n 0 -t $threads -s $SIZE -b 4m --direct --resfile $RESFILE $TESTDIR
+          $ELBENCHO --hosts $host -r -n 0 -t $threads -s $SIZE -b 4m --direct --resfile $RESFILE $TESTDIR
+
+          # Random write and read IOPS for max $TIMELIMIT seconds:
+          $ELBENCHO --hosts $host -w -n 0 -t $threads -s $SIZE -b 4k --direct --iodepth $IODEPTH --rand --timelimit $TIMELIMIT --resfile $RESFILE $TESTDIR
+          $ELBENCHO --hosts $host -r -n 0 -t $threads -s $SIZE -b 4k --direct --iodepth $IODEPTH --rand --timelimit $TIMELIMIT --resfile $RESFILE $TESTDIR
+          $ELBENCHO --hosts $host -F -n 0 -t $threads $TESTDIR
+        done
+    done
+done
+
+$ELBENCHO --hosts $USER@$HOSTS --quit
+```
+
+#### 多文件测试
 ```bash
 #!/usr/bin/env bash
 

--- a/cephadm/3-deploy-cephfs.md
+++ b/cephadm/3-deploy-cephfs.md
@@ -460,7 +460,7 @@ RESFILE=fs.log
 DIRS=1
 FILES=128
 THREADS_LIST="1 4 16 64"
-SIZE_LIST="4k 128k 4m 1g"
+SIZE_LIST="4k 128k 4m 1g 4g"
 HOSTS_LIST="gn001 gn[001-004] gn[001-016]"
 USER=root
 
@@ -480,18 +480,20 @@ for host in $HOSTS_LIST; do
 
     for threads in $thread_list; do
         for size in $SIZE_LIST; do
-            if [[ "$size" == "$LAST_SIZE" ]]; then
+            if [[ "$size" == "1g" ]] || [[ "$size" == "4g" ]]; then
                 files=1
-            else
-                files=$FILES
-            fi
+		            block_size="4m"
+	          else
+            	  files=$FILES
+		            block_size=$size
+	          fi
 
             # Write
             $ELBENCHO --hosts $host  \
-                    -w -d --direct -t $threads -n $DIRS -N $files -s $size -b $size --resfile $RESFILE $TESTDIR
+                    -w -d --direct -t $threads -n $DIRS -N $files -s $size -b $block_size --resfile $RESFILE $TESTDIR
             # Read
             $ELBENCHO --hosts $host  \
-                    -r --direct -t $threads -n $DIRS -N $files -s $size -b $size --resfile $RESFILE $TESTDIR
+                    -r --direct -t $threads -n $DIRS -N $files -s $size -b $block_size --resfile $RESFILE $TESTDIR
             # Delete
             $ELBENCHO --hosts $host  \
                     -D -F -t $threads -n $DIRS -N $files $TESTDIR

--- a/cephadm/3-deploy-cephfs.md
+++ b/cephadm/3-deploy-cephfs.md
@@ -453,7 +453,11 @@ ceph tell mds.bjcfs01.mn01.zxhhrq client ls
 
 经过测试，新版本的elbencho貌似有内存泄漏问题。建议使用v3.0.19版本。
 
-#### 单文件测试
+#### 大文件读写测试
+
+本章节所示脚本主要进行大文件的如下测试：
+1. 4M顺序读写
+1. 4K随机读写
 
 ```bash
 #!/usr/bin/env bash
@@ -466,6 +470,8 @@ RESFILE=fs.log
 THREADS_LIST="1 4 16 64"
 HOSTS_LIST="gn001 gn[001-004] gn[001-016]"
 USER=root
+IODEPTH=16
+TIMELIMIT=20
 
 FIRST_HOST=$(echo $HOSTS_LIST | awk '{print $1}')
 LAST_HOST=$(echo $HOSTS_LIST | awk '{print $NF}')
@@ -500,6 +506,8 @@ $ELBENCHO --hosts $USER@$HOSTS --quit
 ```
 
 #### 多文件测试
+
+
 ```bash
 #!/usr/bin/env bash
 

--- a/cephadm/3-deploy-cephfs.md
+++ b/cephadm/3-deploy-cephfs.md
@@ -492,7 +492,6 @@ for host in $HOSTS_LIST; do
           $ELBENCHO --hosts $host -w -n 0 -t $threads -s $SIZE -b 4k --direct --iodepth $IODEPTH --rand --timelimit $TIMELIMIT --resfile $RESFILE $TESTDIR
           $ELBENCHO --hosts $host -r -n 0 -t $threads -s $SIZE -b 4k --direct --iodepth $IODEPTH --rand --timelimit $TIMELIMIT --resfile $RESFILE $TESTDIR
           $ELBENCHO --hosts $host -F -n 0 -t $threads $TESTDIR
-        done
     done
 done
 

--- a/cephadm/3-deploy-cephfs.md
+++ b/cephadm/3-deploy-cephfs.md
@@ -470,6 +470,7 @@ USER=root
 FIRST_HOST=$(echo $HOSTS_LIST | awk '{print $1}')
 LAST_HOST=$(echo $HOSTS_LIST | awk '{print $NF}')
 LAST_THREAD=$(echo $THREADS_LIST | awk '{print $NF}')
+TOTAL=64
 
 pdsh -w $USER@$LAST_HOST $ELBENCHO --service
 


### PR DESCRIPTION
1. 增加大文件4m顺序读写和4k随机读写
2. 多文件测试脚本中，1g和4g文件大小使用4m块大小，其他块大小与文件大小一致。